### PR TITLE
Fix resize data propagation on button click

### DIFF
--- a/src/AlignmentGuides.js
+++ b/src/AlignmentGuides.js
@@ -776,7 +776,6 @@ class AlignmentGuides extends Component {
 		this.setState({
 			boxes,
 			guides,
-			resizing: false,
 			guidesActive: false
 		}, () => {
 			if (data.type && data.type === 'group') {


### PR DESCRIPTION
Pressing shift key (shortcut to scale maintaining aspect ratio) while resizing stops propagating event to `onResize` handler