### PR TITLE
Bugfix for cursor rotation

### DIFF
--- a/src/Box.js
+++ b/src/Box.js
@@ -10,7 +10,9 @@ import {
 	getLength,
 	getNewCoordinates,
 	getNewStyle,
-	getOffsetCoordinates, centerToTopLeft,
+	getOffsetCoordinates,
+	centerToTopLeft,
+	getResizeCursorCSS,
 } from './utils/helpers';
 import { RESIZE_CORNERS, ROTATE_HANDLES } from './utils/constants';
 import styles from './styles.scss';
@@ -676,7 +678,7 @@ class Box extends Component{
 								className={className}
 								onMouseDown={this.props.resize ? this.onResizeStart : null} // If this.props.resize is false then remove the mouseDown event handler for resize
 								id={`resize-${handle}`}
-								style={{pointerEvents: this.props.isLayerLocked ? 'none' : ''}}
+								style={{pointerEvents: this.props.isLayerLocked ? 'none' : '', cursor: getResizeCursorCSS(this.props.position?.rotateAngle, handle)}}
 							/>;
 						}) :
 						null

--- a/src/Box.js
+++ b/src/Box.js
@@ -651,6 +651,7 @@ class Box extends Component{
 					(this.props.didDragOrResizeHappen) ? <span
 							ref={this.coordinates}
 							className={styles.coordinates}
+							style={{transform: `rotate(-${this.props.position?.rotateAngle}deg)`}}
 						>
 						{`${Math.round(position.x * xFactor)}, ${Math.round(position.y * yFactor)}`}
 					</span> :
@@ -660,7 +661,7 @@ class Box extends Component{
 					(isSelected && !areMultipleBoxesSelected) || (position.type && position.type === 'group') ?
 					(this.props.didDragOrResizeHappen) ? <span
 							className={`${styles.dimensions} `}
-							style={{ width: `${position.width}px`, top: `${position.height + 10}px`, minWidth:'66px' }}
+							style={{ width: `${position.width}px`, top: `${position.height + 10}px`, minWidth:'66px', transform: `rotate(-${this.props.position?.rotateAngle}deg)` }}
 						>
 						<div className={`${styles.dimensions_style}`}>{`${Math.round(position.width * xFactor)} x ${Math.round(position.height * yFactor)}`}</div>
 					</span> :

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -226,10 +226,19 @@
 
 // Load the rotate icon svg and rotate it appropriately for each corner
 .rotateHandle {
-	width: 25px;
-	height: 25px;
+	width: 35px;
+	height: 35px;
 	z-index: 98;
 	opacity: 0;
+	background-repeat: no-repeat;
+	background-color: transparent;
+  background-position: center;
+	border: none;
+	cursor: none;
+
+	&:hover{
+		opacity: 1;
+	}
 }
 
 @svg-load rotate-tr url(./assets/rotate.svg) {
@@ -264,27 +273,27 @@
 }
 
 .rotate-tr {
-	top: -20px;
-	right: -20px;
-	cursor: svg-inline(rotate-tr) 0 0, auto;
+	background-image: svg-inline(rotate-tr);
+	top: -30px;
+	right: -30px;
 }
 
 .rotate-tl {
-	top: -20px;
-	left: -20px;
-	cursor: svg-inline(rotate-tl) 0 0, auto;
+	background-image: svg-inline(rotate-tl);
+	top: -30px;
+	left: -30px;
 }
 
 .rotate-br {
-	bottom: -20px;
-	right: -20px;
-	cursor: svg-inline(rotate-br) 0 0, auto;
+	background-image: svg-inline(rotate-br);
+	bottom: -30px;
+	right: -30px;
 }
 
 .rotate-bl {
-	bottom: -20px;
-	left: -20px;
-	cursor: svg-inline(rotate-bl) 0 0, auto;
+	background-image: svg-inline(rotate-bl);
+	bottom: -30px;
+	left: -30px;
 }
 
 
@@ -405,8 +414,4 @@
 	display: flex;
     align-items: center;
     justify-content: center;
-}
-
-.cropper_notches_container {
-
 }

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -396,3 +396,23 @@ export const getMultipleSelectionCoordinates = (allBoxes, activeBoxes) => {
 };
 
 export const getBoxMetadata = () => {};
+
+const getResizeSVGCursor = (angle) => {
+	return `data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="32px" height="32px" viewBox="0 0 32 32" ><path d="M 16,5 L 12,10 L 14.5,10 L 14.5,22 L 12,22 L 16,27 L 20,22 L 17.5,22 L 17.5,10 L 20, 10 L 16,5 Z" stroke-linejoin="round" stroke-width="1.2" fill="black" stroke="white" style="transform:rotate(${angle}deg);transform-origin: 16px 16px"></path></svg>`;
+}
+
+export const getResizeCursorCSS = (degree, handle) => {
+	let angle = degree;
+
+	if (handle === 'cr' || handle === 'cl') {
+		angle += 90;
+	} else if (handle === 'tr' || handle === 'bl') {
+		angle += 45;
+	} else if (handle === 'br' || handle === 'tl') {
+		angle -= 45;
+	}
+
+	const cursor = getResizeSVGCursor(angle);
+
+	return `url('${cursor}') 16 16, auto`;
+}


### PR DESCRIPTION
Context: Whenever any layer was rotated the cursor would not rotate.

Fix
- Resize Cursor: Added a custom SVG which is being rotated on fly based on the elements rotation.
- Rotate Cursor: Could not mimic the same behavior as the above. Added the SVG as a background-image which would show up as soon as we hover over the region of rotation.