### PR TITLE
preventing deselect on resize or rotate

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "react-alignment-guides",
-	"version": "1.0.1-rc.20",
+	"version": "1.0.1-rc.21",
 	"description": "React Alignment Guides is a guides system for draggable elements in an enclosed space",
 	"keywords": [
 		"drag",

--- a/src/AlignmentGuides.js
+++ b/src/AlignmentGuides.js
@@ -58,6 +58,8 @@ class AlignmentGuides extends Component {
 		this.setPreventShortcutEvents = this.setPreventShortcutEvents.bind(this);
 		this.startingPositions = null;
 		this.didDragOrResizeHappen = false;
+		this.didResizeHappen = false;
+		this.didRotateHappen = false;
 		this.mouseDragHandler = this.mouseDragHandler.bind(this);
 		this.boxSelectByDrag  = this.boxSelectByDrag.bind(this);
 		this.createRectByDrag  = this.createRectByDrag.bind(this);
@@ -500,6 +502,12 @@ class AlignmentGuides extends Component {
 			return;
 		}
 
+		if (this.didResizeHappen || this.didRotateHappen) {
+			this.didResizeHappen = false;
+			this.didRotateHappen = false;
+			return;
+		}
+
 		if (this.props.isEscUnselectActive && (e.type === 'keydown' && (e.key === 'Escape' || e.key === 'Esc'))) {
 			return;
 		}
@@ -841,6 +849,7 @@ class AlignmentGuides extends Component {
 			active: data.node.id,
 			resizing: true
 		});
+		this.didResizeHappen = true;
 		let newData = Object.assign({}, data);
 		if (this.state.boxes[data.node.id].metadata) {
 			newData.metadata = this.state.boxes[data.node.id].metadata;
@@ -1050,6 +1059,7 @@ class AlignmentGuides extends Component {
 			active: data.node.id,
 			rotating: true
 		});
+		this.didRotateHappen = true;
 		this.props.onRotateStart && this.props.onRotateStart(e, data);
 	}
 


### PR DESCRIPTION
Maintaining a state for didResizeHappen and didRotateHappen.
onResizeStart setting it true, and on mouse up, there is a 'click' event triggered which eventually calls 'unselect' for the alignment guides. There preventing unselect and setting those values back to false.

https://www.loom.com/share/0cbb4c862d8f40e085b96404273d0cad