### PR TITLE
Making pointer events none for the multi-select box

### DIFF
--- a/src/Box.js
+++ b/src/Box.js
@@ -729,7 +729,7 @@ class Box extends Component{
 			// }
 
 			if (position.type && position.type === 'group' && isShiftKeyActive ) {
-				if (!areMultipleBoxesSelected) {
+				if (!areMultipleBoxesSelected || id === 'box-ms') {
 					boxStyles.pointerEvents = 'none';
 				}
 				


### PR DESCRIPTION
Making pointer events none for the multi-select box. Excluding the grouped box to preserve the existing behaviour.